### PR TITLE
chore: deduplicate and reorganize .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,48 +1,47 @@
-# Wrangler generated files
+# === Cloudflare / Wrangler ===
 .wrangler/
 .dev.vars
 wrangler.toml.local
 
-# Environment files
+# === Environment Files ===
 .env
 .env.local
 .env.*.local
 
-# Node modules (if you add npm packages later)
+# === Dependencies ===
 node_modules/
 package-lock.json
 yarn.lock
+pnpm-lock.yaml
 
-# OS files
+# === Build Outputs ===
+dist/
+build/
+.cache/
+
+# === OS Files ===
 .DS_Store
 Thumbs.db
+Desktop.ini
 
-# IDE files
+# === IDE / Editor Files ===
 .vscode/
 .idea/
 *.swp
 *.swo
 *~
 
-# Logs
+# === Logs ===
 *.log
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
-# Build outputs (if you add a build step)
-dist/
-build/
-.cache/
-.DS_Store
-
-# Development files
+# === Python (dev tooling) ===
 *.pyc
 __pycache__/
-*.log
-.env.local
 
-# Screenshots and test artifacts
+# === Screenshots & Test Artifacts ===
 *.png
 screenshots/
 debug-*.js
@@ -50,14 +49,3 @@ capture-*.js
 screenshot*.js
 screenshot*.py
 screenshot*.sh
-
-# Editor files
-.vscode/
-.idea/
-*.swp
-*.swo
-*~
-
-# OS files
-.DS_Store
-Thumbs.db


### PR DESCRIPTION
## Summary
Cleans up the `.gitignore` which had multiple duplicate entries and inconsistent organization.

### Fixed
- `.DS_Store` was listed **3 times**
- `.vscode/` was listed **2 times**
- `*.log` was listed **2 times**
- `.env.local` was listed **2 times**
- `*.swp`, `*.swo`, `*~` were listed **2 times**

### Changed
- Reorganized all rules into clearly labeled sections (Cloudflare, Dependencies, Build, OS, IDE, Logs, etc.)
- Added `pnpm-lock.yaml` and `Desktop.ini` coverage

> **Note:** `.DS_Store` and `node_modules/` are still tracked from before the `.gitignore` existed. See issue for cleanup steps.

Co-Authored-By: Oz <oz-agent@warp.dev>