### PR TITLE
fix: replace hash URLs in sitemap.xml with actual page URLs

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,52 +1,60 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  
+
   <!-- Homepage -->
   <url>
     <loc>https://garebear99.github.io/ADMENSION/</loc>
-    <lastmod>2026-01-07</lastmod>
+    <lastmod>2026-02-28</lastmod>
     <changefreq>daily</changefreq>
     <priority>1.0</priority>
   </url>
-  
+
   <!-- Stats Page -->
   <url>
-    <loc>https://garebear99.github.io/ADMENSION/#stats</loc>
-    <lastmod>2026-01-07</lastmod>
+    <loc>https://garebear99.github.io/ADMENSION/stats.html</loc>
+    <lastmod>2026-02-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
-  
+
   <!-- Create Page -->
   <url>
-    <loc>https://garebear99.github.io/ADMENSION/#create</loc>
-    <lastmod>2026-01-07</lastmod>
+    <loc>https://garebear99.github.io/ADMENSION/create.html</loc>
+    <lastmod>2026-02-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
-  
+
   <!-- Manage Page -->
   <url>
-    <loc>https://garebear99.github.io/ADMENSION/#manage</loc>
-    <lastmod>2026-01-07</lastmod>
+    <loc>https://garebear99.github.io/ADMENSION/manage.html</loc>
+    <lastmod>2026-02-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
-  
+
   <!-- Docs Page -->
   <url>
-    <loc>https://garebear99.github.io/ADMENSION/#docs</loc>
-    <lastmod>2026-01-07</lastmod>
+    <loc>https://garebear99.github.io/ADMENSION/docs.html</loc>
+    <lastmod>2026-02-28</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
-  
+
   <!-- Privacy Policy -->
   <url>
     <loc>https://garebear99.github.io/ADMENSION/privacy-policy.html</loc>
-    <lastmod>2026-01-07</lastmod>
+    <lastmod>2026-02-28</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
-  
+
+  <!-- Interstitial (link redirect page) -->
+  <url>
+    <loc>https://garebear99.github.io/ADMENSION/interstitial.html</loc>
+    <lastmod>2026-02-28</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.4</priority>
+  </url>
+
 </urlset>


### PR DESCRIPTION
## Problem
The sitemap was using **hash-fragment URLs** (`/#stats`, `/#create`, `/#manage`, `/#docs`) which Google **cannot index** — hash fragments are never sent to the server and are invisible to crawlers.

This means Google was only indexing 2 of your 7 pages (homepage and privacy policy).

## Fix
- Replaced all hash URLs with actual `.html` file paths (`stats.html`, `create.html`, etc.)
- Added `interstitial.html` to the sitemap
- Updated all `lastmod` dates to current

## Impact
This should improve SEO indexing and may help with AdSense approval, since Google will now see multiple content-rich pages instead of just one.

Co-Authored-By: Oz <oz-agent@warp.dev>