### PR TITLE
fix: repair corrupted check-adsense-status.sh (garbled lines)

### DIFF
--- a/tools/adsense-cli/check-adsense-status.sh
+++ b/tools/adsense-cli/check-adsense-status.sh
@@ -5,6 +5,7 @@
 export PATH="/usr/local/share/google-cloud-sdk/bin:$PATH"
 
 SITE="garebear99.github.io"
+PUB_ID="pub-5584590642779290"
 LOG_FILE="$HOME/.adsense-status.log"
 FIRST_RUN_FLAG="$HOME/.adsense-checker-started"
 
@@ -25,8 +26,10 @@ if [ -z "$TOKEN" ]; then
 fi
 
 RESPONSE=$(curl -s -H "Authorization: Bearer $TOKEN" \
-  -H "x-goog-  -r-project: admension-adsense-api" \
-  "https://adsense.googleapis.com/v2/acco  "https://adsense.googleapis.com/v2/acco  "https://ao "$RESPONSE" | python3 -c "import sys,json; print(json.load(sys.stdin).get('state','UNKNOWN'))" 2>/dev/null)
+  -H "x-goog-user-project: admension-adsense-api" \
+  "https://adsense.googleapis.com/v2/accounts/$PUB_ID/sites/$SITE" 2>/dev/null)
+
+STATUS=$(echo "$RESPONSE" | python3 -c "import sys,json; print(json.load(sys.stdin).get('state','UNKNOWN'))" 2>/dev/null)
 
 # Log the check
 echo "[$TIMESTAMP] Site: $SITE | Status: $STATUS" >> "$LOG_FILE"
@@ -34,13 +37,15 @@ echo "[$TIMESTAMP] Site: $SITE | Status: $STATUS" >> "$LOG_FILE"
 # Check if approved
 if [ "$STATUS" = "READY" ]; then
   # Send APPROVAL notification
-  osascript -e 'display notification   osascript -e 'display notification   osascript -e 'display notification   osascript -e 'display notification   osascript -e 'display ascript -e 'display alert "AdSense Approved!" message "Your site garebear99.github.io has been approved! Ads will now display on ADMENSION. Check your AdSense dashboard for earnings."'
-  
+  osascript -e 'display notification "Your site has been APPROVED! Ads are now live on ADMENSION!" with title "✅ AdSense APPROVED!" sound name "Glass"'
+  osascript -e 'display alert "AdSense Approved!" message "Your site garebear99.github.io has been approved! Ads will now display on ADMENSION. Check your AdSense dashboard for earnings."'
+
   echo "[$TIMESTAMP] ✅ APPROVED! Notification sent." >> "$LOG_FILE"
-  
-  # Send DEACTIVATION notification
+
+  # Disable the checker - no longer needed
   osascript -e 'display notification "Checker has been disabled - no longer needed!" with title "🔕 AdSense Checker Stopped" sound name "Purr"'
-  echo "[$TIMESTAMP] 🔕 Daily checker  echo "[$TIMESTAMP] 🔕 Daily checker  echo "[$TIMESTAMP] 🔕 Daily checker  echo "[$TIMESTAMP] 🔕 Daily checker  echo "[$TIMESTAMP] 🔕 Daily checker  echo "[$TIMESTAMP] 🔕 Daily checker  echo adsense-checker.plist 2>/dev/null
+  echo "[$TIMESTAMP] 🔕 Daily checker disabled (approval received)" >> "$LOG_FILE"
+  launchctl unload "$HOME/Library/LaunchAgents/com.admension.adsense-checker.plist" 2>/dev/null
 else
   echo "[$TIMESTAMP] ⏳ Still waiting... Status: $STATUS" >> "$LOG_FILE"
 fi


### PR DESCRIPTION
## Fix
Repair `tools/adsense-cli/check-adsense-status.sh` which had severe corruption — multiple lines were garbled, truncated, and repeated.

## What was broken
- curl API URL truncated and repeated 3 times
- `osascript` notification call repeated 5 times
- `echo` log line repeated 6 times
- `STATUS` variable never assigned (curl output wasn't captured)
- `PUB_ID` variable missing (hardcoded in main CLI but not in checker)

## What's fixed
- Clean curl call to AdSense API with proper `$PUB_ID` variable
- `STATUS` properly captured from API response
- Single notification on approval, single notification on daemon shutdown
- Proper `launchctl unload` on approval

Co-Authored-By: Oz <oz-agent@warp.dev>