### PR TITLE
fix: move puppeteer from dependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,9 +28,7 @@
     "payout": "node scripts/compute_payouts.mjs"
   },
   "devDependencies": {
-    "playwright": "^1.57.0"
-  },
-  "dependencies": {
+    "playwright": "^1.57.0",
     "puppeteer": "^24.34.0"
   }
 }


### PR DESCRIPTION
## Summary
Moves `puppeteer` from `dependencies` to `devDependencies` in `package.json`.

## Why
Puppeteer is only used by the AdSense CLI tool (`tools/adsense-cli/`) for development and testing — it is not needed at runtime on the deployed GitHub Pages site. Having it in `dependencies` means:
- Production deployments (`npm install --production`) unnecessarily download ~400MB of Chromium
- Netlify/Cloudflare builds take longer than needed
- Security surface area is increased in production

## Changes
- Moved `puppeteer: ^24.34.0` from `dependencies` to `devDependencies`
- Removed the now-empty `dependencies` key

Closes #14

Co-Authored-By: Oz <oz-agent@warp.dev>