### PR TITLE
fix: index.html — remove duplicate AdSense, fix invalid HTML, fix 33%→13%, remove duplicate CSS

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,12 +6,6 @@
 - Viewability-first: avoid timers, refresh only on navigation
 -->
 
-<ul class="micro-proof">
-<li>✔ No signup, no accounts, no email</li>
-<li>✔ Ads only load on user intent (policy-safe)</li>
-<li>✔ Payouts are post-revenue only (no promises)</li>
-<li>✔ Works even at very low traffic</li>
-</ul>
 <!doctype html>
 <html lang="en">
 <head>
@@ -234,95 +228,6 @@ canvas{width:100%;height:72px;border:1px solid rgba(255,255,255,.10);border-radi
   height:100%;
   width:0%;
   background: rgba(110,255,180,.75);
-}
-
-/* ===== v12 Support Button (bottom-left) ===== */
-.supportFab{
-  position: fixed;
-  left: 14px;
-  bottom: 14px;
-  z-index: 99999;
-  display:flex;
-  gap:10px;
-  align-items:center;
-}
-.supportFab .btn{
-  box-shadow: 0 10px 30px rgba(0,0,0,.25);
-}
-.modalOverlay{
-  position: fixed; inset:0;
-  background: rgba(0,0,0,.55);
-  z-index: 100000;
-  display:none;
-  align-items:center;
-  justify-content:center;
-  padding: 18px;
-}
-.modalOverlay.open{ display:flex; }
-.modal{
-  width: min(860px, 100%);
-  max-height: min(86vh, 820px);
-  overflow:auto;
-  border-radius: 16px;
-  background: rgba(20,20,26,.92);
-  border: 1px solid rgba(255,255,255,.10);
-  box-shadow: 0 18px 60px rgba(0,0,0,.55);
-  backdrop-filter: blur(10px);
-}
-.modalHeader{
-  display:flex;
-  justify-content:space-between;
-  align-items:flex-start;
-  gap:12px;
-  padding: 16px 16px 0 16px;
-}
-.modalHeader h2{ margin:0; }
-.modalBody{ padding: 12px 16px 16px 16px; }
-.videoBox{
-  border-radius: 14px;
-  overflow:hidden;
-  border: 1px solid rgba(255,255,255,.12);
-  background: rgba(255,255,255,.05);
-}
-.videoMeta{
-  display:flex;
-  justify-content:space-between;
-  gap:10px;
-  align-items:center;
-  margin-top:10px;
-}
-.pill{
-  display:inline-flex;
-  align-items:center;
-  gap:6px;
-  padding: 6px 10px;
-  border-radius: 999px;
-  background: rgba(255,255,255,.08);
-  border: 1px solid rgba(255,255,255,.10);
-  font-size: 12px;
-}
-.smallRow{
-  display:flex;
-  gap:10px;
-  flex-wrap:wrap;
-  margin-top:10px;
-}
-.donateGrid{
-  display:grid;
-  grid-template-columns: 1fr 1fr;
-  gap:10px;
-}
-@media(max-width: 760px){
-  .donateGrid{ grid-template-columns: 1fr; }
-}
-.addrBox{
-  border-radius: 12px;
-  padding: 10px 12px;
-  border: 1px solid rgba(255,255,255,.10);
-  background: rgba(255,255,255,.06);
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
-  font-size: 12px;
-  word-break: break-all;
 }
 
 
@@ -620,9 +525,6 @@ canvas{width:100%;height:72px;border:1px solid rgba(255,255,255,.10);border-radi
 })();
 </script>
 
-<!-- Google AdSense -->
-<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5584590642779290"
-     crossorigin="anonymous"></script>
 
 <!-- ADMENSION Revenue System -->
     <script src="src/ad-loader.js"></script>
@@ -639,6 +541,12 @@ canvas{width:100%;height:72px;border:1px solid rgba(255,255,255,.10);border-radi
 </head>
 <body>
 
+<ul class="micro-proof">
+<li>✔ No signup, no accounts, no email</li>
+<li>✔ Ads only load on user intent (policy-safe)</li>
+<li>✔ Payouts are post-revenue only (no promises)</li>
+<li>✔ Works even at very low traffic</li>
+</ul>
 <!-- =========================
   AD NETWORK SCRIPT HERE
   Paste ONLY scripts/markup your ad provider gives you.
@@ -1606,7 +1514,7 @@ This system is <b>hands‑free</b>, <b>signup‑free</b>, and <b>idiot‑proof</
   <ul class="tight">
     <li>Users earn <b>participation units</b> during the month (not dollars).</li>
     <li>After the month closes and ad networks actually pay, you enter the <b>received revenue</b> for settlement.</li>
-    <li><b>33%</b> of net received ad revenue is allocated to the ADMENSION pool (cap applies).</li>
+    <li><b>13%</b> of net received ad revenue is allocated to the ADMENSION pool (cap applies).</li>
     <li>User payout is proportional: <code>pool × (your_units / total_units)</code>.</li>
     <li>Minimum redeem threshold can be enforced (e.g., $20) and payouts are only from money already received.</li>
   </ul>


### PR DESCRIPTION
## Summary
Fixes 4 issues in `index.html` that were identified during the production audit.

## Changes

### 1. Remove duplicate AdSense script (Issue #6)
The AdSense `<script>` tag was loaded **twice** in `<head>` (lines 24 and 624). Removed the second instance. Having it twice wastes bandwidth and can cause ad rendering issues.

### 2. Fix invalid HTML structure (Issue #15)
The `<ul class="micro-proof">` block appeared **before** `<!doctype html>`, which puts the browser into quirks mode and can break rendering. Moved it inside `<body>` where it belongs.

### 3. Fix pool percentage inconsistency (Issue #15)
The "ADMENSION Pool Math" docs section said **33%** of net revenue goes to the pool, but every other reference in the codebase says **13%**. Fixed to 13%.

### 4. Remove duplicate CSS blocks
The following CSS classes were defined identically twice in `<style>`:
- `.supportFab`, `.modalOverlay`, `.modal`, `.modalHeader`, `.modalBody`, `.videoBox`, `.videoMeta`, `.pill`, `.smallRow`, `.donateGrid`, `.addrBox`

Removed the duplicate block (~89 lines of redundant CSS).

## Net impact
- **-99 lines** of dead/duplicate code
- **+7 lines** (micro-proof moved to correct location)
- Closes #6, Closes #15

Co-Authored-By: Oz <oz-agent@warp.dev>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed support button and associated modal overlays for a streamlined interface
  * Updated pool allocation percentage to 13% (previously 33%), affecting payout calculations
  * Restored micro-proof section visibility

* **Chores**
  * Removed external ad script dependencies to reduce external loads

<!-- end of auto-generated comment: release notes by coderabbit.ai -->