### PR TITLE
fix: Complete PIN Eradication from Inline JS + Production Hardening

### DIFF
--- a/ADMIN_SETUP.md
+++ b/ADMIN_SETUP.md
@@ -56,24 +56,6 @@ If deploying for public use, consider:
 3. Use proper authentication (OAuth, JWT)
 4. Implement server-side admin API
 
-### Quick Fix for Now
-
-Run this in your browser console on the ADMENSION page:
-
-```javascript
-// Set your custom PIN
-localStorage.setItem('admension_admin_pin', '654321'); // CHANGE THIS
-
-// Update the UI hint
-document.querySelectorAll('*').forEach(el => {
-  if (el.textContent && el.textContent.includes('979899')) {
-    el.textContent = el.textContent.replace('979899', 'YOUR_CUSTOM_PIN');
-  }
-});
-
-alert('Admin PIN updated! Remember your new PIN.');
-```
-
 ## Admin Features Protected by PIN
 
 - Sponsor sticky management

--- a/PRODUCTION_CHECKLIST.md
+++ b/PRODUCTION_CHECKLIST.md
@@ -14,7 +14,7 @@
 - [x] Create page generates links successfully
 - [x] Manage page displays created links
 - [x] Stats page shows analytics
-- [x] Admin page requires PIN (979899)
+- [x] Admin page requires PIN (SHA-256 hashed, set via init-admin-pin.html)
 - [x] Privacy policy accessible
 - [x] Interstitial flow works (3 steps)
 

--- a/admin.html
+++ b/admin.html
@@ -479,7 +479,7 @@ canvas{width:100%;height:72px;border:1px solid rgba(255,255,255,.10);border-radi
 .page{display:none;}
 .page.active{display:block;}
 </style>
-</meta>
+
 <script>
 (function(){
   const K = {
@@ -775,7 +775,7 @@ canvas{width:100%;height:72px;border:1px solid rgba(255,255,255,.10);border-radi
 <div class="ad" id="docsRail"><div class="adLabel">DOCS — Desktop Rail</div></div></section><section class="page" id="page-stats"><section class="card"><h1>Transparency Stats</h1><p class="sub">Local transparency counters (for optimization only).</p><div class="grid kpis"><div class="kpi"><div class="mini">Sessions (24h)</div><div class="big" id="k_sessions_24">—</div></div><div class="kpi"><div class="mini">Pageviews (24h)</div><div class="big" id="k_pv_24">—</div></div><div class="kpi"><div class="mini">Ads shown (24h)</div><div class="big" id="k_ads_24">—</div></div><div class="kpi"><div class="mini">Ads/PV (24h)</div><div class="big" id="k_apv_24">—</div></div><div class="kpi"><div class="mini">Sessions (7d)</div><div class="big" id="k_sessions_7">—</div></div><div class="kpi"><div class="mini">Pageviews (7d)</div><div class="big" id="k_pv_7">—</div></div><div class="kpi"><div class="mini">PV/session (7d)</div><div class="big" id="k_pvps_7">—</div></div><div class="kpi"><div class="mini">Desktop share</div><div class="big" id="k_desktop">—</div></div><div class="kpi"><div class="mini">Reached Step 3</div><div class="big" id="k_step3">—</div></div><div class="kpi"><div class="mini">Top source</div><div class="big" id="k_topsrc">—</div></div></div></section></section><section class="page" id="page-admin">
 <section class="card">
 <h1>Admin</h1>
-<p class="sub">Local controls, sponsor scheduling, and safety notes. Admin actions require PIN 979899.</p>
+<p class="sub">Local controls, sponsor scheduling, and safety notes. Admin actions require your admin PIN.</p>
 <div class="divider"></div>
 <h2>Projection + last-month inputs (local)</h2>
 <div class="notice">
@@ -826,7 +826,7 @@ canvas{width:100%;height:72px;border:1px solid rgba(255,255,255,.10);border-radi
 <h2><span class="not-home">Admin unlock</span></h2>
 <div class="notice warnNote">
             Admin features are locked so random visitors can’t mess with local data.
-            Click <b>Unlock</b> and enter PIN <b>979899</b> to use sponsor controls and reset.
+            Click <b>Unlock</b> and enter your <b>admin PIN</b> to use sponsor controls and reset.
           </div>
 <div class="row" style="margin-top:10px">
 <button class="btn primary" id="btnAdminUnlock">Unlock</button>
@@ -1469,19 +1469,28 @@ function spRenderSticky(){
 let adminUnlocked = false;
 function adminGuard(){
   if(adminUnlocked) return true;
-  alert("Admin is locked. Click Unlock and enter PIN 979899.");
+  alert("Admin is locked. Click Unlock and enter your admin PIN.");
   return false;
 }
-function adminUnlockFlow(){
-  const pin = prompt("Admin PIN:");
-  if(pin===null) return false;
-  if(String(pin).trim() !== "979899"){ alert("Invalid PIN."); return false; }
-  adminUnlocked = true;
-  const st = document.getElementById("adminStatus");
-  if(st) st.textContent = "unlocked";
-  return true;
+async function adminUnlockFlow(){
+if(!window.ADMENSION_ADMIN_AUTH) {
+alert("Admin auth system not loaded. Please refresh the page.");
+return false;
 }
-
+const result = await window.ADMENSION_ADMIN_AUTH.promptAndVerifyPIN("Admin PIN:");
+if(result.error === 'NO_PIN_SET') {
+alert(result.message + "\n\nVisit: " + window.location.origin + "/init-admin-pin.html");
+return false;
+}
+if(!result.valid) {
+alert(result.message);
+return false;
+}
+adminUnlocked = true;
+const st = document.getElementById("adminStatus");
+if(st) st.textContent = "unlocked";
+return true;
+}
 
 
 const clamp = (n,a,b)=>Math.max(a,Math.min(b,n));
@@ -1551,7 +1560,7 @@ function showPage(name){
   // v1.3 hard lock: admin page requires PIN
   if(name==="admin" && !adminUnlocked){
     setRobotsForRoute();
-    alert("Admin is locked. Use Unlock (PIN 979899).");
+    alert("Admin is locked. Use Unlock and enter your admin PIN.");
     location.hash = "#home";
     name = "home";
   }
@@ -1771,10 +1780,10 @@ if(fileImport){
 /* ===== Admin reset (PIN) ===== */
 const btnReset = document.getElementById("btnReset");
 if(btnReset){
-  btnReset.onclick = () => {
-    const pin = prompt("Admin PIN to reset stats:");
-    if(pin === null) return;
-    if(String(pin).trim() !== "979899"){ alert("Invalid PIN."); return; }
+  btnReset.onclick = async () => {
+    // Use secure hash-based PIN verification
+    
+    if(!window.ADMENSION_ADMIN_AUTH) { alert("Auth system not loaded."); return; } const r = await window.ADMENSION_ADMIN_AUTH.promptAndVerifyPIN("Admin PIN to reset stats:"); if(!r.valid) { if(r.error !== "CANCELLED") alert(r.message); return; }
     if(!confirm("Reset ALL saved stats and ADMENSION links on this browser?")) return;
     localStorage.removeItem(K.sessions);
     localStorage.removeItem(K.ads);

--- a/create.html
+++ b/create.html
@@ -479,7 +479,7 @@ canvas{width:100%;height:72px;border:1px solid rgba(255,255,255,.10);border-radi
 .page{display:none;}
 .page.active{display:block;}
 </style>
-</meta>
+
 <script>
 (function(){
   const K = {
@@ -775,7 +775,7 @@ canvas{width:100%;height:72px;border:1px solid rgba(255,255,255,.10);border-radi
 <div class="ad" id="docsRail"><div class="adLabel">DOCS — Desktop Rail</div></div></section><section class="page" id="page-stats"><section class="card"><h1>Transparency Stats</h1><p class="sub">Local transparency counters (for optimization only).</p><div class="grid kpis"><div class="kpi"><div class="mini">Sessions (24h)</div><div class="big" id="k_sessions_24">—</div></div><div class="kpi"><div class="mini">Pageviews (24h)</div><div class="big" id="k_pv_24">—</div></div><div class="kpi"><div class="mini">Ads shown (24h)</div><div class="big" id="k_ads_24">—</div></div><div class="kpi"><div class="mini">Ads/PV (24h)</div><div class="big" id="k_apv_24">—</div></div><div class="kpi"><div class="mini">Sessions (7d)</div><div class="big" id="k_sessions_7">—</div></div><div class="kpi"><div class="mini">Pageviews (7d)</div><div class="big" id="k_pv_7">—</div></div><div class="kpi"><div class="mini">PV/session (7d)</div><div class="big" id="k_pvps_7">—</div></div><div class="kpi"><div class="mini">Desktop share</div><div class="big" id="k_desktop">—</div></div><div class="kpi"><div class="mini">Reached Step 3</div><div class="big" id="k_step3">—</div></div><div class="kpi"><div class="mini">Top source</div><div class="big" id="k_topsrc">—</div></div></div></section></section><section class="page" id="page-admin">
 <section class="card">
 <h1>Admin</h1>
-<p class="sub">Local controls, sponsor scheduling, and safety notes. Admin actions require PIN 979899.</p>
+<p class="sub">Local controls, sponsor scheduling, and safety notes. Admin actions require your admin PIN.</p>
 <div class="divider"></div>
 <h2>Projection + last-month inputs (local)</h2>
 <div class="notice">
@@ -826,7 +826,7 @@ canvas{width:100%;height:72px;border:1px solid rgba(255,255,255,.10);border-radi
 <h2><span class="not-home">Admin unlock</span></h2>
 <div class="notice warnNote">
             Admin features are locked so random visitors can’t mess with local data.
-            Click <b>Unlock</b> and enter PIN <b>979899</b> to use sponsor controls and reset.
+            Click <b>Unlock</b> and enter your <b>admin PIN</b> to use sponsor controls and reset.
           </div>
 <div class="row" style="margin-top:10px">
 <button class="btn primary" id="btnAdminUnlock">Unlock</button>
@@ -1469,19 +1469,28 @@ function spRenderSticky(){
 let adminUnlocked = false;
 function adminGuard(){
   if(adminUnlocked) return true;
-  alert("Admin is locked. Click Unlock and enter PIN 979899.");
+  alert("Admin is locked. Click Unlock and enter your admin PIN.");
   return false;
 }
-function adminUnlockFlow(){
-  const pin = prompt("Admin PIN:");
-  if(pin===null) return false;
-  if(String(pin).trim() !== "979899"){ alert("Invalid PIN."); return false; }
-  adminUnlocked = true;
-  const st = document.getElementById("adminStatus");
-  if(st) st.textContent = "unlocked";
-  return true;
+async function adminUnlockFlow(){
+if(!window.ADMENSION_ADMIN_AUTH) {
+alert("Admin auth system not loaded. Please refresh the page.");
+return false;
 }
-
+const result = await window.ADMENSION_ADMIN_AUTH.promptAndVerifyPIN("Admin PIN:");
+if(result.error === 'NO_PIN_SET') {
+alert(result.message + "\n\nVisit: " + window.location.origin + "/init-admin-pin.html");
+return false;
+}
+if(!result.valid) {
+alert(result.message);
+return false;
+}
+adminUnlocked = true;
+const st = document.getElementById("adminStatus");
+if(st) st.textContent = "unlocked";
+return true;
+}
 
 
 const clamp = (n,a,b)=>Math.max(a,Math.min(b,n));
@@ -1551,7 +1560,7 @@ function showPage(name){
   // v1.3 hard lock: admin page requires PIN
   if(name==="admin" && !adminUnlocked){
     setRobotsForRoute();
-    alert("Admin is locked. Use Unlock (PIN 979899).");
+    alert("Admin is locked. Use Unlock and enter your admin PIN.");
     location.hash = "#home";
     name = "home";
   }
@@ -1771,10 +1780,10 @@ if(fileImport){
 /* ===== Admin reset (PIN) ===== */
 const btnReset = document.getElementById("btnReset");
 if(btnReset){
-  btnReset.onclick = () => {
-    const pin = prompt("Admin PIN to reset stats:");
-    if(pin === null) return;
-    if(String(pin).trim() !== "979899"){ alert("Invalid PIN."); return; }
+  btnReset.onclick = async () => {
+    // Use secure hash-based PIN verification
+    
+    if(!window.ADMENSION_ADMIN_AUTH) { alert("Auth system not loaded."); return; } const r = await window.ADMENSION_ADMIN_AUTH.promptAndVerifyPIN("Admin PIN to reset stats:"); if(!r.valid) { if(r.error !== "CANCELLED") alert(r.message); return; }
     if(!confirm("Reset ALL saved stats and ADMENSION links on this browser?")) return;
     localStorage.removeItem(K.sessions);
     localStorage.removeItem(K.ads);

--- a/docs.html
+++ b/docs.html
@@ -479,7 +479,7 @@ canvas{width:100%;height:72px;border:1px solid rgba(255,255,255,.10);border-radi
 .page{display:none;}
 .page.active{display:block;}
 </style>
-</meta>
+
 <script>
 (function(){
   const K = {
@@ -1160,7 +1160,7 @@ test('ADMENSION homepage loads', async ({ page }) => {
 <section class="page" id="page-admin">
 <section class="card">
 <h1>Admin</h1>
-<p class="sub">Local controls, sponsor scheduling, and safety notes. Admin actions require PIN 979899.</p>
+<p class="sub">Local controls, sponsor scheduling, and safety notes. Admin actions require your admin PIN.</p>
 <div class="divider"></div>
 <h2>Projection + last-month inputs (local)</h2>
 <div class="notice">
@@ -1211,7 +1211,7 @@ test('ADMENSION homepage loads', async ({ page }) => {
 <h2><span class="not-home">Admin unlock</span></h2>
 <div class="notice warnNote">
             Admin features are locked so random visitors can’t mess with local data.
-            Click <b>Unlock</b> and enter PIN <b>979899</b> to use sponsor controls and reset.
+            Click <b>Unlock</b> and enter your <b>admin PIN</b> to use sponsor controls and reset.
           </div>
 <div class="row" style="margin-top:10px">
 <button class="btn primary" id="btnAdminUnlock">Unlock</button>
@@ -1854,19 +1854,28 @@ function spRenderSticky(){
 let adminUnlocked = false;
 function adminGuard(){
   if(adminUnlocked) return true;
-  alert("Admin is locked. Click Unlock and enter PIN 979899.");
+  alert("Admin is locked. Click Unlock and enter your admin PIN.");
   return false;
 }
-function adminUnlockFlow(){
-  const pin = prompt("Admin PIN:");
-  if(pin===null) return false;
-  if(String(pin).trim() !== "979899"){ alert("Invalid PIN."); return false; }
-  adminUnlocked = true;
-  const st = document.getElementById("adminStatus");
-  if(st) st.textContent = "unlocked";
-  return true;
+async function adminUnlockFlow(){
+if(!window.ADMENSION_ADMIN_AUTH) {
+alert("Admin auth system not loaded. Please refresh the page.");
+return false;
 }
-
+const result = await window.ADMENSION_ADMIN_AUTH.promptAndVerifyPIN("Admin PIN:");
+if(result.error === 'NO_PIN_SET') {
+alert(result.message + "\n\nVisit: " + window.location.origin + "/init-admin-pin.html");
+return false;
+}
+if(!result.valid) {
+alert(result.message);
+return false;
+}
+adminUnlocked = true;
+const st = document.getElementById("adminStatus");
+if(st) st.textContent = "unlocked";
+return true;
+}
 
 
 const clamp = (n,a,b)=>Math.max(a,Math.min(b,n));
@@ -1936,7 +1945,7 @@ function showPage(name){
   // v1.3 hard lock: admin page requires PIN
   if(name==="admin" && !adminUnlocked){
     setRobotsForRoute();
-    alert("Admin is locked. Use Unlock (PIN 979899).");
+    alert("Admin is locked. Use Unlock and enter your admin PIN.");
     location.hash = "#home";
     name = "home";
   }
@@ -2156,10 +2165,10 @@ if(fileImport){
 /* ===== Admin reset (PIN) ===== */
 const btnReset = document.getElementById("btnReset");
 if(btnReset){
-  btnReset.onclick = () => {
-    const pin = prompt("Admin PIN to reset stats:");
-    if(pin === null) return;
-    if(String(pin).trim() !== "979899"){ alert("Invalid PIN."); return; }
+  btnReset.onclick = async () => {
+    // Use secure hash-based PIN verification
+    
+    if(!window.ADMENSION_ADMIN_AUTH) { alert("Auth system not loaded."); return; } const r = await window.ADMENSION_ADMIN_AUTH.promptAndVerifyPIN("Admin PIN to reset stats:"); if(!r.valid) { if(r.error !== "CANCELLED") alert(r.message); return; }
     if(!confirm("Reset ALL saved stats and ADMENSION links on this browser?")) return;
     localStorage.removeItem(K.sessions);
     localStorage.removeItem(K.ads);

--- a/manage.html
+++ b/manage.html
@@ -479,7 +479,7 @@ canvas{width:100%;height:72px;border:1px solid rgba(255,255,255,.10);border-radi
 .page{display:none;}
 .page.active{display:block;}
 </style>
-</meta>
+
 <script>
 (function(){
   const K = {
@@ -884,7 +884,7 @@ canvas{width:100%;height:72px;border:1px solid rgba(255,255,255,.10);border-radi
 <div class="ad" id="docsRail"><div class="adLabel">DOCS — Desktop Rail</div></div></section><section class="page" id="page-stats"><section class="card"><h1>Transparency Stats</h1><p class="sub">Local transparency counters (for optimization only).</p><div class="grid kpis"><div class="kpi"><div class="mini">Sessions (24h)</div><div class="big" id="k_sessions_24">—</div></div><div class="kpi"><div class="mini">Pageviews (24h)</div><div class="big" id="k_pv_24">—</div></div><div class="kpi"><div class="mini">Ads shown (24h)</div><div class="big" id="k_ads_24">—</div></div><div class="kpi"><div class="mini">Ads/PV (24h)</div><div class="big" id="k_apv_24">—</div></div><div class="kpi"><div class="mini">Sessions (7d)</div><div class="big" id="k_sessions_7">—</div></div><div class="kpi"><div class="mini">Pageviews (7d)</div><div class="big" id="k_pv_7">—</div></div><div class="kpi"><div class="mini">PV/session (7d)</div><div class="big" id="k_pvps_7">—</div></div><div class="kpi"><div class="mini">Desktop share</div><div class="big" id="k_desktop">—</div></div><div class="kpi"><div class="mini">Reached Step 3</div><div class="big" id="k_step3">—</div></div><div class="kpi"><div class="mini">Top source</div><div class="big" id="k_topsrc">—</div></div></div></section></section><section class="page" id="page-admin">
 <section class="card">
 <h1>Admin</h1>
-<p class="sub">Local controls, sponsor scheduling, and safety notes. Admin actions require PIN 979899.</p>
+<p class="sub">Local controls, sponsor scheduling, and safety notes. Admin actions require your admin PIN.</p>
 <div class="divider"></div>
 <h2>Projection + last-month inputs (local)</h2>
 <div class="notice">
@@ -935,7 +935,7 @@ canvas{width:100%;height:72px;border:1px solid rgba(255,255,255,.10);border-radi
 <h2><span class="not-home">Admin unlock</span></h2>
 <div class="notice warnNote">
             Admin features are locked so random visitors can’t mess with local data.
-            Click <b>Unlock</b> and enter PIN <b>979899</b> to use sponsor controls and reset.
+            Click <b>Unlock</b> and enter your <b>admin PIN</b> to use sponsor controls and reset.
           </div>
 <div class="row" style="margin-top:10px">
 <button class="btn primary" id="btnAdminUnlock">Unlock</button>
@@ -1578,19 +1578,28 @@ function spRenderSticky(){
 let adminUnlocked = false;
 function adminGuard(){
   if(adminUnlocked) return true;
-  alert("Admin is locked. Click Unlock and enter PIN 979899.");
+  alert("Admin is locked. Click Unlock and enter your admin PIN.");
   return false;
 }
-function adminUnlockFlow(){
-  const pin = prompt("Admin PIN:");
-  if(pin===null) return false;
-  if(String(pin).trim() !== "979899"){ alert("Invalid PIN."); return false; }
-  adminUnlocked = true;
-  const st = document.getElementById("adminStatus");
-  if(st) st.textContent = "unlocked";
-  return true;
+async function adminUnlockFlow(){
+if(!window.ADMENSION_ADMIN_AUTH) {
+alert("Admin auth system not loaded. Please refresh the page.");
+return false;
 }
-
+const result = await window.ADMENSION_ADMIN_AUTH.promptAndVerifyPIN("Admin PIN:");
+if(result.error === 'NO_PIN_SET') {
+alert(result.message + "\n\nVisit: " + window.location.origin + "/init-admin-pin.html");
+return false;
+}
+if(!result.valid) {
+alert(result.message);
+return false;
+}
+adminUnlocked = true;
+const st = document.getElementById("adminStatus");
+if(st) st.textContent = "unlocked";
+return true;
+}
 
 
 const clamp = (n,a,b)=>Math.max(a,Math.min(b,n));
@@ -1660,7 +1669,7 @@ function showPage(name){
   // v1.3 hard lock: admin page requires PIN
   if(name==="admin" && !adminUnlocked){
     setRobotsForRoute();
-    alert("Admin is locked. Use Unlock (PIN 979899).");
+    alert("Admin is locked. Use Unlock and enter your admin PIN.");
     location.hash = "#home";
     name = "home";
   }
@@ -1880,10 +1889,10 @@ if(fileImport){
 /* ===== Admin reset (PIN) ===== */
 const btnReset = document.getElementById("btnReset");
 if(btnReset){
-  btnReset.onclick = () => {
-    const pin = prompt("Admin PIN to reset stats:");
-    if(pin === null) return;
-    if(String(pin).trim() !== "979899"){ alert("Invalid PIN."); return; }
+  btnReset.onclick = async () => {
+    // Use secure hash-based PIN verification
+    
+    if(!window.ADMENSION_ADMIN_AUTH) { alert("Auth system not loaded."); return; } const r = await window.ADMENSION_ADMIN_AUTH.promptAndVerifyPIN("Admin PIN to reset stats:"); if(!r.valid) { if(r.error !== "CANCELLED") alert(r.message); return; }
     if(!confirm("Reset ALL saved stats and ADMENSION links on this browser?")) return;
     localStorage.removeItem(K.sessions);
     localStorage.removeItem(K.ads);

--- a/stats.html
+++ b/stats.html
@@ -479,7 +479,7 @@ canvas{width:100%;height:72px;border:1px solid rgba(255,255,255,.10);border-radi
 .page{display:none;}
 .page.active{display:block;}
 </style>
-</meta>
+
 
 <!-- ADMENSION Revenue System (synced with index.html) -->
 <script src="./src/admin-auth.js"></script>
@@ -741,7 +741,7 @@ canvas{width:100%;height:72px;border:1px solid rgba(255,255,255,.10);border-radi
 <div class="ad" id="docsRail"><div class="adLabel">DOCS — Desktop Rail</div></div></section><section class="page" id="page-stats"><section class="card"><h1>Transparency Stats</h1><p class="sub">Local transparency counters (for optimization only).</p><div class="grid kpis"><div class="kpi"><div class="mini">Sessions (24h)</div><div class="big" id="k_sessions_24">—</div></div><div class="kpi"><div class="mini">Pageviews (24h)</div><div class="big" id="k_pv_24">—</div></div><div class="kpi"><div class="mini">Ads shown (24h)</div><div class="big" id="k_ads_24">—</div></div><div class="kpi"><div class="mini">Ads/PV (24h)</div><div class="big" id="k_apv_24">—</div></div><div class="kpi"><div class="mini">Sessions (7d)</div><div class="big" id="k_sessions_7">—</div></div><div class="kpi"><div class="mini">Pageviews (7d)</div><div class="big" id="k_pv_7">—</div></div><div class="kpi"><div class="mini">PV/session (7d)</div><div class="big" id="k_pvps_7">—</div></div><div class="kpi"><div class="mini">Desktop share</div><div class="big" id="k_desktop">—</div></div><div class="kpi"><div class="mini">Reached Step 3</div><div class="big" id="k_step3">—</div></div><div class="kpi"><div class="mini">Top source</div><div class="big" id="k_topsrc">—</div></div></div></section></section><section class="page" id="page-admin">
 <section class="card">
 <h1>Admin</h1>
-<p class="sub">Local controls, sponsor scheduling, and safety notes. Admin actions require PIN 979899.</p>
+<p class="sub">Local controls, sponsor scheduling, and safety notes. Admin actions require your admin PIN.</p>
 <div class="divider"></div>
 <h2>Projection + last-month inputs (local)</h2>
 <div class="notice">
@@ -792,7 +792,7 @@ canvas{width:100%;height:72px;border:1px solid rgba(255,255,255,.10);border-radi
 <h2><span class="not-home">Admin unlock</span></h2>
 <div class="notice warnNote">
             Admin features are locked so random visitors can’t mess with local data.
-            Click <b>Unlock</b> and enter PIN <b>979899</b> to use sponsor controls and reset.
+            Click <b>Unlock</b> and enter your <b>admin PIN</b> to use sponsor controls and reset.
           </div>
 <div class="row" style="margin-top:10px">
 <button class="btn primary" id="btnAdminUnlock">Unlock</button>
@@ -1435,19 +1435,28 @@ function spRenderSticky(){
 let adminUnlocked = false;
 function adminGuard(){
   if(adminUnlocked) return true;
-  alert("Admin is locked. Click Unlock and enter PIN 979899.");
+  alert("Admin is locked. Click Unlock and enter your admin PIN.");
   return false;
 }
-function adminUnlockFlow(){
-  const pin = prompt("Admin PIN:");
-  if(pin===null) return false;
-  if(String(pin).trim() !== "979899"){ alert("Invalid PIN."); return false; }
-  adminUnlocked = true;
-  const st = document.getElementById("adminStatus");
-  if(st) st.textContent = "unlocked";
-  return true;
+async function adminUnlockFlow(){
+if(!window.ADMENSION_ADMIN_AUTH) {
+alert("Admin auth system not loaded. Please refresh the page.");
+return false;
 }
-
+const result = await window.ADMENSION_ADMIN_AUTH.promptAndVerifyPIN("Admin PIN:");
+if(result.error === 'NO_PIN_SET') {
+alert(result.message + "\n\nVisit: " + window.location.origin + "/init-admin-pin.html");
+return false;
+}
+if(!result.valid) {
+alert(result.message);
+return false;
+}
+adminUnlocked = true;
+const st = document.getElementById("adminStatus");
+if(st) st.textContent = "unlocked";
+return true;
+}
 
 
 const clamp = (n,a,b)=>Math.max(a,Math.min(b,n));
@@ -1517,7 +1526,7 @@ function showPage(name){
   // v1.3 hard lock: admin page requires PIN
   if(name==="admin" && !adminUnlocked){
     setRobotsForRoute();
-    alert("Admin is locked. Use Unlock (PIN 979899).");
+    alert("Admin is locked. Use Unlock and enter your admin PIN.");
     location.hash = "#home";
     name = "home";
   }
@@ -1737,10 +1746,10 @@ if(fileImport){
 /* ===== Admin reset (PIN) ===== */
 const btnReset = document.getElementById("btnReset");
 if(btnReset){
-  btnReset.onclick = () => {
-    const pin = prompt("Admin PIN to reset stats:");
-    if(pin === null) return;
-    if(String(pin).trim() !== "979899"){ alert("Invalid PIN."); return; }
+  btnReset.onclick = async () => {
+    // Use secure hash-based PIN verification
+    
+    if(!window.ADMENSION_ADMIN_AUTH) { alert("Auth system not loaded."); return; } const r = await window.ADMENSION_ADMIN_AUTH.promptAndVerifyPIN("Admin PIN to reset stats:"); if(!r.valid) { if(r.error !== "CANCELLED") alert(r.message); return; }
     if(!confirm("Reset ALL saved stats and ADMENSION links on this browser?")) return;
     localStorage.removeItem(K.sessions);
     localStorage.removeItem(K.ads);

--- a/worker.js
+++ b/worker.js
@@ -151,8 +151,8 @@ async function createLink(data, env) {
   // Update global stats: increment total created
   await incrementGlobalStat(env, 'created');
 
-  // Live site base URL
-  const SITE_BASE = 'https://garebear99.github.io/ADMENSION';
+  // Live site base URL (configurable via Cloudflare Worker env variable)
+  const SITE_BASE = env.SITE_BASE_URL || 'https://garebear99.github.io/ADMENSION';
 
   return jsonResponse({
     success: true,


### PR DESCRIPTION
## CRITICAL: Complete PIN Eradication + Production Hardening

PR #26 removed the PIN from the header badge, but a deeper scan revealed the **actual authentication bypass** — all 5 sub-pages had the old plaintext PIN `979899` hardcoded directly in their inline JavaScript:

### Security Fixes
- **`adminUnlockFlow()`** — Replaced old `if(String(pin).trim() !== '979899')` plaintext comparison with async `ADMENSION_ADMIN_AUTH.promptAndVerifyPIN()` (SHA-256 hash verification)
- **`btnReset.onclick`** — Same fix for the admin reset function
- **All PIN text references** — Removed from alert messages, HTML paragraphs, and UI labels across all 5 sub-pages

### Production Cleanup
- **`worker.js`** — `SITE_BASE` now reads from `env.SITE_BASE_URL` with GitHub Pages fallback, making it configurable via Cloudflare dashboard
- **Invalid HTML** — Removed `</meta>` closing tags (meta is void element)
- **`ADMIN_SETUP.md`** — Removed stale "Quick Fix" section that referenced old plaintext PIN system
- **`PRODUCTION_CHECKLIST.md`** — Updated PIN reference to note SHA-256 hash system

### Verification
```bash
grep -r '979899' stats.html create.html manage.html docs.html admin.html
# Returns: nothing (all instances removed)
```

Co-Authored-By: Oz <oz-agent@warp.dev>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Centralized admin authentication system for improved security and flexibility.

* **Bug Fixes**
  * Migrated admin unlock flow to asynchronous verification system.

* **Documentation**
  * Updated production checklist reflecting new SHA-256 hashed PIN setup mechanism.

* **Chores**
  * Removed browser console-based PIN override feature.
  * Made site base URL configurable via environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->