### PR TITLE
feat: add event collection to Cloudflare Worker + wire collector URL

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -3091,7 +3091,7 @@ function apsInitAdminControls(){
 <script>
 window.ADMENSION_API_URL = 'https://admension-api.admension.workers.dev';
 // Event collector — deploy cloud/apps_script_collector.gs.txt, paste Web App URL here:
-window.ADMENSION_COLLECTOR_URL = 'https://script.google.com/macros/s/AKfycby9N_niT-aRVnStj5aULOZ95EoJ4HU_vP4os4_BcmgixPvNA2a4JDEfgKikhpVX9wHc/exec';
+window.ADMENSION_COLLECTOR_URL = 'https://admension-api.admension.workers.dev/api/events';
 </script>
 <script src="./src/api-client.js"></script>
 </body>

--- a/create.html
+++ b/create.html
@@ -3091,7 +3091,7 @@ function apsInitAdminControls(){
 <script>
 window.ADMENSION_API_URL = 'https://admension-api.admension.workers.dev';
 // Event collector — deploy cloud/apps_script_collector.gs.txt, paste Web App URL here:
-window.ADMENSION_COLLECTOR_URL = 'https://script.google.com/macros/s/AKfycby9N_niT-aRVnStj5aULOZ95EoJ4HU_vP4os4_BcmgixPvNA2a4JDEfgKikhpVX9wHc/exec';
+window.ADMENSION_COLLECTOR_URL = 'https://admension-api.admension.workers.dev/api/events';
 </script>
 <script src="./src/api-client.js"></script>
 </body>

--- a/docs.html
+++ b/docs.html
@@ -3476,7 +3476,7 @@ function apsInitAdminControls(){
 <script>
 window.ADMENSION_API_URL = 'https://admension-api.admension.workers.dev';
 // Event collector — deploy cloud/apps_script_collector.gs.txt, paste Web App URL here:
-window.ADMENSION_COLLECTOR_URL = 'https://script.google.com/macros/s/AKfycby9N_niT-aRVnStj5aULOZ95EoJ4HU_vP4os4_BcmgixPvNA2a4JDEfgKikhpVX9wHc/exec';
+window.ADMENSION_COLLECTOR_URL = 'https://admension-api.admension.workers.dev/api/events';
 </script>
 <script src="./src/api-client.js"></script>
 </body>

--- a/index.html
+++ b/index.html
@@ -4781,7 +4781,7 @@ function apsInitAdminControls(){
   // Set Cloudflare Worker API URL
   window.ADMENSION_API_URL = 'https://admension-api.admension.workers.dev';
   // Event collector — deploy cloud/apps_script_collector.gs.txt, paste Web App URL here:
-  window.ADMENSION_COLLECTOR_URL = 'https://script.google.com/macros/s/AKfycby9N_niT-aRVnStj5aULOZ95EoJ4HU_vP4os4_BcmgixPvNA2a4JDEfgKikhpVX9wHc/exec';
+  window.ADMENSION_COLLECTOR_URL = 'https://admension-api.admension.workers.dev/api/events';
 </script>
 <!-- Load API client library -->
 <script src="./src/api-client.js"></script>

--- a/interstitial.html
+++ b/interstitial.html
@@ -515,7 +515,7 @@
 <script>
   window.ADMENSION_API_URL = 'https://admension-api.admension.workers.dev';
   // Event collector — deploy cloud/apps_script_collector.gs.txt, paste Web App URL here:
-  window.ADMENSION_COLLECTOR_URL = 'https://script.google.com/macros/s/AKfycby9N_niT-aRVnStj5aULOZ95EoJ4HU_vP4os4_BcmgixPvNA2a4JDEfgKikhpVX9wHc/exec';
+  window.ADMENSION_COLLECTOR_URL = 'https://admension-api.admension.workers.dev/api/events';
 </script>
 <script src="./src/consent.js"></script>
 <script src="./src/api-client.js"></script>

--- a/manage.html
+++ b/manage.html
@@ -3374,7 +3374,7 @@ function apsInitAdminControls(){
 <script>
 window.ADMENSION_API_URL = 'https://admension-api.admension.workers.dev';
 // Event collector — deploy cloud/apps_script_collector.gs.txt, paste Web App URL here:
-window.ADMENSION_COLLECTOR_URL = 'https://script.google.com/macros/s/AKfycby9N_niT-aRVnStj5aULOZ95EoJ4HU_vP4os4_BcmgixPvNA2a4JDEfgKikhpVX9wHc/exec';
+window.ADMENSION_COLLECTOR_URL = 'https://admension-api.admension.workers.dev/api/events';
 </script>
 <script src="./src/api-client.js"></script>
 </body>

--- a/stats.html
+++ b/stats.html
@@ -3057,7 +3057,7 @@ function apsInitAdminControls(){
 <script>
 window.ADMENSION_API_URL = 'https://admension-api.admension.workers.dev';
 // Event collector — deploy cloud/apps_script_collector.gs.txt, paste Web App URL here:
-window.ADMENSION_COLLECTOR_URL = 'https://script.google.com/macros/s/AKfycby9N_niT-aRVnStj5aULOZ95EoJ4HU_vP4os4_BcmgixPvNA2a4JDEfgKikhpVX9wHc/exec';
+window.ADMENSION_COLLECTOR_URL = 'https://admension-api.admension.workers.dev/api/events';
 </script>
 <script src="./src/api-client.js"></script>
 <script>

--- a/worker.js
+++ b/worker.js
@@ -31,6 +31,12 @@ const RATE_LIMITS = {
     perHour: 50,        // 50 updates per hour
     perDay: 200,        // 200 updates per day
   },
+  // Event collection limits (POST /api/events)
+  events: {
+    perMinute: 30,      // 30 events per minute per IP
+    perHour: 500,       // 500 events per hour
+    perDay: 5000,       // 5,000 events per day
+  },
 };
 
 // Progressive timeout durations (in seconds)
@@ -106,6 +112,12 @@ export default {
       if (request.method === 'POST' && path.match(/\/api\/links\/[A-Z0-9]+\/pageview$/i)) {
         const code = path.split('/').slice(-2, -1)[0].toUpperCase();
         return await trackPageview(code, env);
+      }
+
+      // POST /api/events - Collect analytics events
+      if (request.method === 'POST' && path === '/api/events') {
+        const body = await request.json();
+        return await collectEvent(body, clientIP, env);
       }
 
       return jsonResponse({ error: 'Not found' }, 404);
@@ -294,6 +306,7 @@ async function checkRateLimit(request, clientIP, path, env) {
   // Determine action type
   let action = 'fetch';
   if (request.method === 'POST' && path === '/api/links') action = 'create';
+  else if (request.method === 'POST' && path === '/api/events') action = 'events';
   else if (request.method === 'PUT') action = 'update';
   
   const limits = RATE_LIMITS[action];
@@ -507,6 +520,45 @@ async function incrementGlobalStat(env, statName) {
   } catch (error) {
     console.error('Failed to increment global stat:', error);
   }
+}
+
+/**
+ * Collect an analytics event (pageview, ad_request, ad_viewable, wallet_submit)
+ */
+async function collectEvent(body, clientIP, env) {
+  const allowedTypes = ['pageview', 'ad_request', 'ad_viewable', 'wallet_submit', 'create_link', 'list_links'];
+  const type = body.type || '';
+
+  if (!type || !allowedTypes.includes(type)) {
+    return jsonResponse({ ok: false, error: 'invalid_type' }, 400);
+  }
+
+  const event = {
+    ts: Date.now(),
+    type,
+    ip_hash: await hashIP(clientIP),
+    payload: body.payload || {},
+  };
+
+  // Store in KV with a unique key; 30-day TTL
+  const key = `event:${type}:${Date.now()}:${Math.random().toString(36).slice(2, 8)}`;
+  await env.ADMENSION_LINKS.put(key, JSON.stringify(event), { expirationTtl: 2592000 });
+
+  // Increment daily event counter for simple analytics
+  const dayKey = `eventcount:${getCurrentDay()}`;
+  await incrementCounter(env, dayKey, 172800); // 2-day TTL
+
+  return jsonResponse({ ok: true });
+}
+
+/**
+ * Hash an IP address for privacy-safe storage
+ */
+async function hashIP(ip) {
+  const data = new TextEncoder().encode(ip + ':admension-salt');
+  const hash = await crypto.subtle.digest('SHA-256', data);
+  const bytes = new Uint8Array(hash);
+  return Array.from(bytes.slice(0, 8)).map(b => b.toString(16).padStart(2, '0')).join('');
 }
 
 /**


### PR DESCRIPTION
## Summary
Add event collection to the existing Cloudflare Worker and wire the live endpoint into all pages. This replaces the Apps Script approach with a faster, simpler solution using infrastructure already in place.

## Changes
### Worker (`worker.js`)
- **New endpoint**: `POST /api/events` — accepts analytics events and stores them in KV (30-day TTL)
- **Rate limiting**: 30/min, 500/hr, 5,000/day per IP
- **Privacy**: IP addresses SHA-256 hashed before storage
- **Event types**: `pageview`, `ad_request`, `ad_viewable`, `wallet_submit`, `create_link`, `list_links`
- Daily event counters for simple analytics

### HTML Files (all 7)
- Set `window.ADMENSION_COLLECTOR_URL` to `https://admension-api.admension.workers.dev/api/events`

## Why Worker instead of Apps Script
- Lower latency (Cloudflare edge network vs Apps Script cold starts)
- No OAuth authorization headaches
- Already integrated with existing KV infrastructure
- Already deployed and battle-tested

## Verified
```
$ curl -X POST -H 'Content-Type: application/json' \
  -d '{"type":"pageview","payload":{"page":"test"}}' \
  https://admension-api.admension.workers.dev/api/events
{"ok":true}
```

Closes #13

Co-Authored-By: Oz <oz-agent@warp.dev>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Event tracking now includes rate limiting to prevent overuse.
  * Added privacy-preserving mechanisms for event data collection.

* **Chores**
  * Updated event collection endpoint infrastructure across all interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->